### PR TITLE
overload plus and minus operators so PDL::Complex won't hang this module

### DIFF
--- a/lib/PDL/DateTime.pm
+++ b/lib/PDL/DateTime.pm
@@ -22,7 +22,9 @@ use overload '>'  => \&_num_compare_gt,
              '<=' => \&_num_compare_le,
              '==' => \&_num_compare_eq,
              '!=' => \&_num_compare_ne,
-             '""' => \&_stringify;
+             '""' => \&_stringify,
+             '+'  => sub { PDL::plus(@_) },
+             '-'  => sub { PDL::minus(@_) };
 
 my %INC_SECONDS = (
   week   => 60 * 60 * 24 * 7,


### PR DESCRIPTION
This is for #1 

There are actually another way to fix the issue that is to patch those functions like replacing `$self` in  `($self - ($self % 1000))` with `$self->{PDL}`. But I prefer my present change as it's simpler. 